### PR TITLE
wording changed

### DIFF
--- a/src/pages/Blogs.tsx
+++ b/src/pages/Blogs.tsx
@@ -48,7 +48,7 @@ export default function Blogs() {
                 Redirecting to blogs.ameys.eu in {countdown}...
             </p>
             <p style={{ fontSize: "1rem", maxWidth: "520px" }}>
-                Redirecting to blogs.ameys.eu in 5..4...3..2...1. If you're not automatically redirected <a href={BLOG_URL}>click here</a>.
+                If you're not automatically redirected <a href={BLOG_URL}>click here</a>.
             </p>
             <button className="redirect-button" onClick={handleRedirect}>
                 Go to Amey's Blogs


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Style
  * Simplified and de-duplicated redirect copy on the Blogs page by removing the explicit “5..4..3..2..1” narration.
  * Now displays a single countdown line (“Redirecting to blogs.ameys.eu in {countdown}…”) with a clear link to proceed immediately.
  * No behavioral changes: automatic redirect still occurs after 5 seconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->